### PR TITLE
Update point in time

### DIFF
--- a/src/layouts/homepage/MissionSection.astro
+++ b/src/layouts/homepage/MissionSection.astro
@@ -36,7 +36,7 @@ import { ChevronRight } from "@lucide/astro";
     <div
       class="mission-card p-[10px] px-[5px] w-full sm:p-[25px] sm:px-[34px] text-lg font-normal leading-7 text-center rounded-lg bg-subbg-4 sm:w-[307.5px]"
     >
-      <p>Tools that transcend the traditional point in time check</p>
+      <p>Tools that transcend the traditional point-in-time check</p>
     </div>
     <div
       class="mission-card p-[10px] px-[5px] w-full sm:p-[25px] sm:px-[34px] text-lg font-normal leading-7 text-center rounded-lg bg-subbg-4 sm:w-[307.5px]"


### PR DESCRIPTION
this should be hyphenated since it describes the noun. This is also the way we use it in other places, e.g. "et yourself apart with automation that goes beyond point-in-time audits"